### PR TITLE
use hot-fixed version to read files with missing trigger entries.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-https://github.com/cta-sst-1m/protozfitsreader/archive/v0.44.1a0.tar.gz
+https://github.com/cta-sst-1m/protozfitsreader/archive/v0.44.1b0.tar.gz
 -e git+https://github.com/cta-observatory/pyhessio.git#egg=pyhessio
 -e git+https://github.com/cta-observatory/ctapipe.git#egg=ctapipe
 -e git+https://github.com/cta-observatory/ctapipe-extra.git#egg=ctapipe-extra

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-https://github.com/cta-sst-1m/protozfitsreader/archive/v0.44.1.tar.gz
+https://github.com/cta-sst-1m/protozfitsreader/archive/v0.44.1a0.tar.gz
 -e git+https://github.com/cta-observatory/pyhessio.git#egg=pyhessio
 -e git+https://github.com/cta-observatory/ctapipe.git#egg=ctapipe
 -e git+https://github.com/cta-observatory/ctapipe-extra.git#egg=ctapipe-extra


### PR DESCRIPTION
There is a hotfix now to read zfits files with missing trigger keys.

This is the modification:
https://github.com/cta-sst-1m/protozfitsreader/compare/work_on_v0.44.1_a
