### PR TITLE
remove telescope_id from calibration_event_stream

### DIFF
--- a/digicampipe/io/event_stream.py
+++ b/digicampipe/io/event_stream.py
@@ -47,7 +47,7 @@ def event_stream(filelist, source=None, max_events=None, **kwargs):
             yield event
 
 
-def calibration_event_stream(path, telescope_id,
+def calibration_event_stream(path,
                              pixel_id=[...],
                              max_events=None):
     """
@@ -57,8 +57,7 @@ def calibration_event_stream(path, telescope_id,
 
     container = CalibrationContainer()
     for event in event_stream(path, max_events=max_events):
-        r0_event = event.r0.tel[telescope_id]
-
+        r0_event = list(event.r0.tel.values())[0]
         container.pixel_id = np.arange(r0_event.adc_samples.shape[0])[pixel_id]
         container.data.adc_samples = r0_event.adc_samples[pixel_id]
         container.data.digicam_baseline = r0_event.digicam_baseline[pixel_id]

--- a/digicampipe/scripts/spe.py
+++ b/digicampipe/scripts/spe.py
@@ -559,7 +559,6 @@ def main(args):
 
     files = args['INPUT']
     debug = args['--debug']
-    telescope_id = 1
 
     max_events = _convert_max_events_args(args['--max_events'])
     output_file = args['FILE']
@@ -575,14 +574,12 @@ def main(args):
         if not os.path.exists(output_file):
 
             events = calibration_event_stream(files,
-                                              telescope_id=telescope_id,
                                               pixel_id=pixel_id,
                                               max_events=max_events)
             raw_histo = build_raw_data_histogram(events)
             save_container(raw_histo, output_file, 'histo', 'raw_lsb')
 
             events = calibration_event_stream(files,
-                                              telescope_id=telescope_id,
                                               max_events=max_events,
                                               pixel_id=pixel_id)
 

--- a/digicampipe/tests/test_calibration_container.py
+++ b/digicampipe/tests/test_calibration_container.py
@@ -35,7 +35,7 @@ def test_calibration_event_stream():
 
     for i, event in enumerate(obs_stream):
 
-        event = event.r0.tel[telescope_id]
+        event = list(event.r0.tel.values())[0]
 
         assert (values[i][0] == event.adc_samples).all()
 

--- a/digicampipe/tests/test_calibration_container.py
+++ b/digicampipe/tests/test_calibration_container.py
@@ -15,9 +15,7 @@ example_file_path = pkg_resources.resource_filename(
 def test_calibration_event_stream():
 
     max_events = 10
-    telescope_id = 1
     calib_stream = calibration_event_stream(example_file_path,
-                                            telescope_id,
                                             max_events=max_events)
 
     values = []


### PR DESCRIPTION
When trying to do `digicam-spe` on observed data I had a problem with the `telescope_id`. Apparently the telescope id in toy-mc files is different from the telescope_id in observations. 

AFAIK we are not interested in setting this number at all, since we **know** in both observations and toy-mc, we only have a single telescope...

So in this PR I remove the explicit value of `telescope_id` and simply use the 1st entry of `event.r0.tel`. 
`tel` is a map (think `dict`) ... but still one can ask a `dict` for a list of all its values and simply take the 1st value. As long as this dict only has a single value anyway, the 1st is always the correct one.

I do not check if there length of the values is exactly one. This means, this will fail as soon as we try this on files with more than one telescope. It might fail silently...meaning that it might simply take one of the many telescopes into account.

I sincerely think this is not a problem inside digicampipe. It would be a problem in ctapipe.