### PR TITLE
use default utils.DigiCam as camera, no need for the user to specify

### DIFF
--- a/digicampipe/io/hessio_digicam.py
+++ b/digicampipe/io/hessio_digicam.py
@@ -73,9 +73,14 @@ def hessio_get_list_event_ids(url, max_events=None):
                            .format(url))
 
 
-def hessio_event_source(url, camera_geometry, camera, max_events=None,
-                        allowed_tels=None, requested_event=None,
-                        use_event_id=False):
+def hessio_event_source(
+    url,
+    camera=utils.DigiCam,
+    max_events=None,
+    allowed_tels=None,
+    requested_event=None,
+    use_event_id=False
+):
     """A generator that streams data from an EventIO/HESSIO MC data file
     (e.g. a standard CTA data file.)
 
@@ -83,6 +88,7 @@ def hessio_event_source(url, camera_geometry, camera, max_events=None,
     ----------
     url : str
         path to file to open
+    camera : utils.Camera() default: utils.DigiCam
     max_events : int, optional
         maximum number of events to read
     allowed_tels : list[int]
@@ -174,7 +180,7 @@ def hessio_event_source(url, camera_geometry, camera, max_events=None,
             data.dl1.tel.clear()
             data.mc.tel.clear()  # clear the previous telescopes
 
-            _fill_instrument_info(data, pyhessio_file, camera_geometry, camera)
+            _fill_instrument_info(data, pyhessio_file, camera)
 
             for tel_id in data.r0.tels_with_data:
 
@@ -231,7 +237,7 @@ def hessio_event_source(url, camera_geometry, camera, max_events=None,
                 return
 
 
-def _fill_instrument_info(data, pyhessio_file, camera_geometry, camera):
+def _fill_instrument_info(data, pyhessio_file, camera):
     """
     fill the data.inst structure with instrumental information.
 
@@ -273,7 +279,7 @@ def _fill_instrument_info(data, pyhessio_file, camera_geometry, camera):
                 data.inst.mirror_dish_area[tel_id] = mirror_area
                 data.inst.mirror_numtiles[tel_id] = num_tiles
 
-                geometry = camera_geometry
+                geometry = camera.geometry
                 patch_matrix = \
                     utils.geometry.compute_patch_matrix(camera=camera)
                 cluster_7_matrix = \

--- a/simtel_pipeline.py
+++ b/simtel_pipeline.py
@@ -20,7 +20,6 @@ Options:
   -h --help     Show this screen.
   -o <path>, --outfile_path=<path>  path to the output files
   -s <name>, --outfile_suffix=<name>    suffix of the output files
-  -c <path>, --camera_config=<path> camera config file to load Camera()
   -i <int>, --picture_threshold     [default: 15]
   -b <int>, --boundary_threshold    [default: 7]
   -d <int>, --baseline0             [default: 9]
@@ -31,12 +30,10 @@ import numpy as np
 import matplotlib.pyplot as plt
 import astropy.units as u
 from digicampipe.io.event_stream import event_stream
-from digicampipe.utils import geometry
-from cts_core.camera import Camera
-from digicampipe.utils import utils
-from digicampipe.io.save_hillas import save_hillas_parameters_in_text, \
+from digicampipe.io.save_hillas import (
+    save_hillas_parameters_in_text,
     save_hillas_parameters
-
+)
 from digicampipe.calib.camera import dl0, dl2, filter, r1, dl1
 from digicampipe.utils import utils, calib
 import simtel_baseline
@@ -46,23 +43,7 @@ from docopt import docopt
 
 
 def main(args):
-
-    # Input/Output files
-    digicam_config_file = args['--camera_config']
-
     dark_baseline = None
-
-    # Source coordinates (in camera frame)
-    source_x = 0. * u.mm
-    source_y = 0. * u.mm
-
-    # Camera and Geometry objects
-    # (mapping, pixel, patch + x,y coordinates pixels)
-    digicam = Camera(_config_file=digicam_config_file)
-    digicam_geometry = geometry.generate_geometry_from_camera(
-                        camera=digicam,
-                        source_x=source_x,
-                        source_y=source_y)
 
     # Noisy pixels not taken into account in Hillas
     pixel_not_wanted = [
@@ -109,10 +90,7 @@ def main(args):
     reclean = True
 
     # Define the event stream
-    data_stream = event_stream(
-        args['<files>'],
-        camera_geometry=digicam_geometry,
-        camera=digicam)
+    data_stream = event_stream(args['<files>'])
 
     # Clean pixels
     data_stream = filter.set_pixels_to_zero(

--- a/simtel_pipeline.py
+++ b/simtel_pipeline.py
@@ -5,7 +5,6 @@ Example:
   ./simtel_pipeline.py \
   --outfile_path=./ \
   --outfile_suffix=gamma_ze00_az000 \
-  --camera_config=./digicampipe/tests/resources/camera_config.cfg \
   --picture_threshold=15 \
   --boundary_threshold=7 \
   --baseline0=9 \


### PR DESCRIPTION
In this PR (which is branched from jurysek_simtel2) I propose to remove the camera config file. 

This makes it easier for the user. 

It also makes the code less general, in case somebody really wants to perform an analysis with different camera configurations, this PR is totally wrong. 

Maybe somebody wants to try it out.