### PR TITLE
execute long running tests in daily cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ install:
 script:
 - pytest digicampipe
 - make -C docs/ html
+- pytest -c digicampipe/all_tests.ini
+  -if: TRAVIS_EVENT_TYPE = cron
 env:
   global:
   - GITHUB_REPO: github.com/cta-sst-1m/digicampipe.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,10 @@ install:
 script:
 - pytest digicampipe
 - make -C docs/ html
-- pytest -c digicampipe/all_tests.ini
-  -if: TRAVIS_EVENT_TYPE = cron
+- |
+  if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]; then
+    pytest -c digicampipe/all_tests.ini
+  fi
 env:
   global:
   - GITHUB_REPO: github.com/cta-sst-1m/digicampipe.git


### PR DESCRIPTION
Here I try to execute the long running tests only when `TRAVIS_EVENT_TYPE = cron`, but I am not sure about the conditionals in travis.yml files ... so I will be testing a lot.