### PR TITLE
fix to plt_rate_vs_threshold

### DIFF
--- a/digicampipe/scripts/plt_rate_vs_threshold.py
+++ b/digicampipe/scripts/plt_rate_vs_threshold.py
@@ -13,13 +13,14 @@ for path in args['<trigger_npz_file>']:
     file_name = split(path)[-1][:-4]
     file = np.load(path)
     plt.errorbar(
-        file['threshold'],
+        file['thresholds'],
         file['rate'] * 1E9,
         yerr=file['rate_error'] * 1E9,
         label=file_name)
 
 plt.ylabel('rate [Hz]')
 plt.xlabel('threshold [LSB]')
-plt.set_yscale('log')
+plt.yscale('log')
+plt.grid(True)
 plt.legend(loc='best')
 plt.show()


### PR DESCRIPTION
Fix to make plt_rate_vs_threshold compatible with rate_scan.py script. Changes: x-axis changed to 'thresholds', plt.yscale fixed, grid added to the plot.