### PR TITLE
use_protozfits_v.1.4.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   - recommonmark==0.4.0
   - secretstorage
   - sphinx-automodapi
-  - https://github.com/cta-sst-1m/protozfitsreader/archive/using_cython_generated_wrapper.tar.gz
+  - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.4.0.tar.gz
   - git+https://github.com/cta-observatory/ctapipe.git#egg=ctapipe
   - git+https://github.com/cta-sst-1m/CTS.git#egg=CTS
   - git+https://github.com/dstndstn/astrometry.net.git#egg=astrometry

--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   - recommonmark==0.4.0
   - secretstorage
   - sphinx-automodapi
-  - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.0.2.tar.gz
+  - https://github.com/cta-sst-1m/protozfitsreader/archive/using_cython_generated_wrapper.tar.gz
   - git+https://github.com/cta-observatory/ctapipe.git#egg=ctapipe
   - git+https://github.com/cta-sst-1m/CTS.git#egg=CTS
   - git+https://github.com/dstndstn/astrometry.net.git#egg=astrometry


### PR DESCRIPTION
In this PR I propose to use the not yet released version of protozfits v.1.4.0.

It is currently under development in a branch named `using_cython_generated_wrapper`, so I just use that branch here.

Since `using_cython_generated_wrapper` does not yet contain the OSX binaries we do expect the OSX tests to fail.

---- 

in the digicampipe code nothing should need to change.