### PR TITLE
fix precission problem in ns timestamps

### DIFF
--- a/digicampipe/io/containers.py
+++ b/digicampipe/io/containers.py
@@ -22,6 +22,7 @@ import pickle
 from os.path import isfile
 from ctapipe.io.serializer import Serializer
 from os import remove
+import numpy as np
 
 __all__ = ['InstrumentContainer',
            'R0Container',
@@ -152,8 +153,8 @@ class R0CameraContainer(Container):
     hv_off_baseline = Field(ndarray, 'HV off baseline')
     camera_event_id = Field(int, 'Camera event number')
     camera_event_number = Field(int, "camera event number")
-    local_camera_clock = Field(float, "camera timestamp")
-    gps_time = Field(float, "gps timestamp")
+    local_camera_clock = Field(np.int64, "camera timestamp")
+    gps_time = Field(np.int64, "gps timestamp")
     white_rabbit_time = Field(float, "precise white rabbit based timestamp")
     camera_event_type = Field(int, "camera event type")
     array_event_type = Field(int, "array event type")

--- a/digicampipe/io/containers.py
+++ b/digicampipe/io/containers.py
@@ -301,9 +301,9 @@ class ReconstructedShowerContainer(Container):
     az_uncertainty = Field(0.0, 'reconstructed azimuth uncertainty',
                            unit=u.deg)
     core_x = Field(0.0, 'reconstructed x coordinate of the core position',
-                  unit=u.m)
+                   unit=u.m)
     core_y = Field(0.0, 'reconstructed y coordinate of the core position',
-                  unit=u.m)
+                   unit=u.m)
     core_uncertainty = Field(0.0, 'uncertainty of the reconstructed core \
                              position', unit=u.m)
     h_max = Field(0.0, 'reconstructed height of the shower maximum')

--- a/digicampipe/io/zfits.py
+++ b/digicampipe/io/zfits.py
@@ -94,10 +94,12 @@ def zfits_event_source(
                 r0.camera_event_number = event.eventNumber
                 r0.pixel_flags = event.pixels_flags[_sort_ids]
                 r0.local_camera_clock = (
-                    event.local_time_sec * 1E9 + event.local_time_nanosec
+                    np.int64(event.local_time_sec * 1E9) +
+                    np.int64(event.local_time_nanosec)
                 )
                 r0.gps_time = (
-                    event.trig.timeSec * 1E9 + event.trig.timeNanoSec
+                    np.int64(event.trig.timeSec * 1E9) +
+                    np.int64(event.trig.timeNanoSec)
                 )
                 r0.camera_event_type = event.event_type
                 r0.array_event_type = event.eventType

--- a/digicampipe/io/zfits.py
+++ b/digicampipe/io/zfits.py
@@ -84,8 +84,10 @@ def zfits_event_source(
                 if tel_id not in loaded_telescopes:
                     data.inst.num_channels[tel_id] = event.num_gains
                     data.inst.geom[tel_id] = camera.geometry
-                    data.inst.cluster_matrix_7[tel_id] = camera.cluster_7_matrix
-                    data.inst.cluster_matrix_19[tel_id] = camera.cluster_19_matrix
+                    data.inst.cluster_matrix_7[tel_id] = \
+                        camera.cluster_7_matrix
+                    data.inst.cluster_matrix_19[tel_id] = \
+                        camera.cluster_19_matrix
                     data.inst.patch_matrix[tel_id] = camera.patch_matrix
                     data.inst.num_pixels[tel_id] = samples.shape[0]
                     data.inst.num_samples[tel_id] = samples.shape[1]


### PR DESCRIPTION
if one do:
```
from digicampipe.io.event_stream import event_stream
events = event_stream('/sst1m/raw/2018/09/01/SST1M_01/SST1M_01_20180901_196.fits.fz')
event = next(events)
tel = event.r0.tels_with_data[0]
t = event.r0.tel[tel].local_camera_clock
print(t - (t+1))
```
with the current code, it prints 0 !
That's because local_camera_clock is defined as a float and floats does not seems to have 10^18 precision.
Using integers instead fixes the problem.