### PR TITLE
compute PDE, XT, Gain drop as function of baseline shift

### DIFF
--- a/digicampipe/calib/baseline.py
+++ b/digicampipe/calib/baseline.py
@@ -91,6 +91,42 @@ def compute_gain_drop(events, bias_resistance, cell_capacitance):
         yield event
 
 
+def _gain_drop_from_baseline_shift(baseline_shift, p=np.array([1., -5.252*1e-3, 2.35*1e-5, 5.821*1e-8])):
+    """
+    Compute the gain drop from baseline shift (assuming nominal gain of 5.01 LSB/p..e)
+    Parameters obtained from Monte-Carlo model of SiPM voltage drop
+    :param baseline_shift:
+    :param p
+    :return:
+    """
+
+    return np.polyval(p.T, baseline_shift)
+
+
+def _crosstalk_drop_from_baseline_shift(baseline_shift, p=np.array([1., -9.425*1e-3, 5.463*1e-5, -1.503*1e-8])):
+    """
+    Compute the crosstalk drop from baseline shift (assuming nominal gain of 5.01 LSB/p..e)
+    Parameters obtained from Monte-Carlo model of SiPM voltage drop
+    :param baseline_shift:
+    :param p
+    :return:
+    """
+
+    return np.polyval(p.T, baseline_shift)
+
+
+def _pde_drop_from_baseline_shift(baseline_shift, p=np.array([1., -2.187*1e-3, 5.199*1e-6])):
+    """
+    Compute the PDE (@ 468nm) drop from baseline shift (assuming nominal gain of 5.01 LSB/p..e)
+    Parameters obtained from Monte-Carlo model of SiPM voltage drop
+    :param baseline_shift:
+    :param p
+    :return:
+    """
+
+    return np.polyval(p.T, baseline_shift)
+
+
 def fill_baseline_r0(event_stream, n_bins=10000):
     n_events = None
     baselines = []


### PR DESCRIPTION
This implements latest Baseline shift to PDE, XT, Gain drop function.
To be used in the `pipeline.py` at some point