### PR TITLE
changin v0.6 from histogram

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -44,5 +44,5 @@ dependencies:
   - git+https://github.com/cta-observatory/ctapipe.git
   - git+https://github.com/cta-sst-1m/CTS.git
   - git+https://github.com/dstndstn/astrometry.net.git
-  - https://github.com/cta-sst-1m/histogram/archive/0.3.2.tar.gz
+  - https://github.com/cta-sst-1m/histogram/archive/0.6.tar.gz
   - git+https://github.com/uvemas/ViTables.git


### PR DESCRIPTION
See changes in https://github.com/cta-sst-1m/histogram/releases/tag/0.6
Should not affect digicampipe (let's see how the test go :D)