### PR TITLE
Rate scan baobab

### DIFF
--- a/bash/rate_scan.sh
+++ b/bash/rate_scan.sh
@@ -1,9 +1,16 @@
-#!/usr/bin/env bash
-#SBATCH --time=04:00:00
+#!/bin/bash
+#SBATCH --time=02:00:00
 #SBATCH --partition=mono
-#SBATCH --mem=16G
+#SBATCH --mem=4G
 #SBATCH --output=/home/%u/job_logs/%x-%A_%a.out
 #SBATCH --job-name='sst-1m-rate-scan'
+
+source activate digicampipe
+
+START=0
+END=4095
+STEP=1
+N_SAMPLES=1024
 
 DIR_NAME=$1 # Directory for the night to produce rate scan
 OUTPUT_DIR=$(echo $DIR_NAME | cut -d '/' -f  5,6,7)
@@ -14,24 +21,26 @@ if ! [[ -d $DIR_NAME ]]; then
 fi
 
 FILES=($(ls -d $DIR_NAME*fits.fz))
-# echo ${FILES[@]}
+N_FILES=${#FILES[@]}
 
+FILES=${FILES[$SLURM_ARRAY_TASK_ID]}
 
+if ! [[ -z $SLURM_ARRAY_TASK_ID ]]; then
 
-START=0
-END=4095
-STEP=1
-N_SAMPLES=1024
-
-
-for FILE in "${FILES[@]}"
+    if [[ $SLURM_ARRAY_TASK_COUNT -ne $N_FILES ]]; then
+        echo "Number of array : "$SLURM_ARRAY_TASK_COUNT " must match number of files :"$N_FILES
+        exit 1
+    fi
+fi
+FILES_TO_PROCESS=${FILES[$SLURM_ARRAY_TASK_ID]}
+for FILE in "${FILES_TO_PROCESS[@]}"
 do
     BASENAME=$(basename "${FILE}")
     BASENAME=$(echo $BASENAME | cut -d'.' -f 1)
     FIGURE=$OUTPUT_DIR'/rate_scan_'$BASENAME'.png'
     OUTPUT=$OUTPUT_DIR'/rate_scan_'$BASENAME'.fits'
-    echo digicam-rate-scan --compute --threshold_step=$STEP --threshold_end=$END --threshold_start=$START --n_samples=$N_SAMPLES --figure_path=$FIGURE --output=$OUTPUT $FILE
+    digicam-rate-scan --compute --threshold_step=$STEP --threshold_end=$END --threshold_start=$START --n_samples=$N_SAMPLES --figure_path=$FIGURE --output=$OUTPUT $FILE
 done
 
-
-
+cd $OUTPUT_DIR
+convert -delay 20 -loop 0 rate_scan*.png rate_scan.gif

--- a/bash/rate_scan.sh
+++ b/bash/rate_scan.sh
@@ -7,9 +7,13 @@ STEP=1
 N_SAMPLES=1024
 
 DIR=$(dirname "${FILE}")
+DIR=$(echo $DIR | cut -d '/' -f  5,6,7)
+DIR='/sst1m/analyzed/'$DIR
+ls $DIR -ltr
+
 BASENAME=$(basename "${FILE}")
 BASENAME=$(echo $BASENAME | cut -d'.' -f 1)
 FIGURE=$DIR'/rate_scan_'$BASENAME'.png'
 OUTPUT=$DIR'/rate_scan_'$BASENAME'.fits'
 
-digicam-rate-scan --compute --threshold_step=$STEP --threshold_end=$END --threshold_start=$START --n_samples=$N_SAMPLES --figure_path=$FIGURE --output=$OUTPUT $FILE
+echo digicam-rate-scan --compute --threshold_step=$STEP --threshold_end=$END --threshold_start=$START --n_samples=$N_SAMPLES --figure_path=$FIGURE --output=$OUTPUT $FILE

--- a/bash/rate_scan.sh
+++ b/bash/rate_scan.sh
@@ -1,19 +1,37 @@
 #!/usr/bin/env bash
+#SBATCH --time=04:00:00
+#SBATCH --partition=mono
+#SBATCH --mem=16G
+#SBATCH --output=/home/%u/job_logs/%x-%A_%a.out
+#SBATCH --job-name='sst-1m-rate-scan'
 
-FILE=$1
+DIR_NAME=$1 # Directory for the night to produce rate scan
+OUTPUT_DIR=$(echo $DIR_NAME | cut -d '/' -f  5,6,7)
+OUTPUT_DIR='/sst1m/analyzed/'$OUTPUT_DIR
+if ! [[ -d $DIR_NAME ]]; then
+    echo "$DIR_NAME must be a directory"
+    exit 1
+fi
+
+FILES=($(ls -d $DIR_NAME*fits.fz))
+# echo ${FILES[@]}
+
+
+
 START=0
 END=4095
 STEP=1
 N_SAMPLES=1024
 
-DIR=$(dirname "${FILE}")
-DIR=$(echo $DIR | cut -d '/' -f  5,6,7)
-DIR='/sst1m/analyzed/'$DIR
-ls $DIR -ltr
 
-BASENAME=$(basename "${FILE}")
-BASENAME=$(echo $BASENAME | cut -d'.' -f 1)
-FIGURE=$DIR'/rate_scan_'$BASENAME'.png'
-OUTPUT=$DIR'/rate_scan_'$BASENAME'.fits'
+for FILE in "${FILES[@]}"
+do
+    BASENAME=$(basename "${FILE}")
+    BASENAME=$(echo $BASENAME | cut -d'.' -f 1)
+    FIGURE=$OUTPUT_DIR'/rate_scan_'$BASENAME'.png'
+    OUTPUT=$OUTPUT_DIR'/rate_scan_'$BASENAME'.fits'
+    echo digicam-rate-scan --compute --threshold_step=$STEP --threshold_end=$END --threshold_start=$START --n_samples=$N_SAMPLES --figure_path=$FIGURE --output=$OUTPUT $FILE
+done
 
-echo digicam-rate-scan --compute --threshold_step=$STEP --threshold_end=$END --threshold_start=$START --n_samples=$N_SAMPLES --figure_path=$FIGURE --output=$OUTPUT $FILE
+
+

--- a/bash/rate_scan.sh
+++ b/bash/rate_scan.sh
@@ -2,7 +2,7 @@
 #SBATCH --time=02:00:00
 #SBATCH --partition=mono
 #SBATCH --mem=4G
-#SBATCH --output=/home/%u/job_logs/%x-%A_%a.out
+#SBATCH --output=/home/%u/job_logs/%x-%A_%a.out # TO BE CHANGED
 #SBATCH --job-name='sst-1m-rate-scan'
 
 source activate digicampipe

--- a/bash/rate_scan.sh
+++ b/bash/rate_scan.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+FILE=$1
+START=0
+END=4095
+STEP=1
+N_SAMPLES=1024
+
+DIR=$(dirname "${FILE}")
+BASENAME=$(basename "${FILE}")
+BASENAME=$(echo $BASENAME | cut -d'.' -f 1)
+FIGURE=$DIR'/rate_scan_'$BASENAME'.png'
+OUTPUT=$DIR'/rate_scan_'$BASENAME'.fits'
+
+digicam-rate-scan --compute --threshold_step=$STEP --threshold_end=$END --threshold_start=$START --n_samples=$N_SAMPLES --figure_path=$FIGURE --output=$OUTPUT $FILE

--- a/digicampipe/calib/baseline.py
+++ b/digicampipe/calib/baseline.py
@@ -154,7 +154,7 @@ def fill_baseline_r0(event_stream, n_bins=10000):
             if n_events is None:
                 n_events = n_bins // adc_samples.shape[1]
 
-            if r0_camera.camera_event_type in CameraEventType.INTERNAL:
+            if CameraEventType.INTERNAL in r0_camera.camera_event_type:
 
                 baselines.append(adc_samples.mean(axis=1))
                 baselines = baselines[-n_events:]

--- a/digicampipe/calib/filters.py
+++ b/digicampipe/calib/filters.py
@@ -32,9 +32,11 @@ def set_pixels_to_zero(event_stream, unwanted_pixels):
 def filter_event_types(event_stream, flags=(CameraEventType.PATCH7,)):
     for event in event_stream:
         for telescope_id in event.r0.tels_with_data:
-            flag = event.r0.tel[telescope_id].camera_event_type
-            if flag in flags:
-                yield event
+            event_type = event.r0.tel[telescope_id].camera_event_type
+
+            for flag in flags:
+                if flag in event_type:
+                    yield event
 
 
 def filter_shower(event_stream, min_photon):


### PR DESCRIPTION
I created an sbatch/bash script to run the rate scan analysis. On baobab it should be ran like this:

```bash
sbatch --array=0-68 rate_scan.sh /sst1m/rsync_data/raw/2018/11/12/SST1M_01/
```

where `--array=0-N_FILES_IN_NIGHT` and the second argument is the path to the data for a given night.

effectively it will run `digicam-rate-scan` on each of the files present in the dir : `/sst1m/rsync_data/raw/2018/11/12/SST1M_01/` and then create the output in : `/sst1m/analyzed/2018/11/12/` with a `rate_scan.gif` file.

Unfortunately I cannot write into `/sst1m/analyzed/2018/11/12/`. @yrenier can you make use of this script in the cron jobs or do I need to change it ?

N.B. I commented the parts that should be changed by the user